### PR TITLE
Enhance Infisical secrets check action functionality

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,12 @@
 name: "Infisical secrets check"
 description: "Run Infisical secrets check on a GitHub repository."
 branding:
-  icon: 'alert-triangle'
-  color: 'green'
+  icon: "alert-triangle"
+  color: "green"
+outputs:
+  secrets-leaked:
+    description: "The number of secrets leaked found by the Infisical CLI tool."
+    value: ${{ steps.count.outputs.secrets-leaked }}
 runs:
   using: "composite"
   steps:
@@ -31,6 +35,16 @@ runs:
           csv-to-markdown-table --delim , --headers < secrets-result.csv > secrets-result.md
           awk -F, '{print $NF}' < secrets.csv | tail -n +2 > fingerprint.txt
         fi
+
+    - name: Count secrets leaked
+      shell: bash
+      id: count
+      run: |
+        quantity=0
+        if [[ -s fingerprint.txt ]]; then
+            quantity=$(wc -l fingerprint.txt | cut -c1)
+        fi
+        echo "secrets-leaked=$(echo $quantity)" >> $GITHUB_OUTPUT
 
     - name: Upload artifacts secrets-result.log
       uses: actions/upload-artifact@v4
@@ -108,9 +122,14 @@ runs:
       if: failure()
       with:
         refresh-message-position: true
-        message-id: "secrets-result"        
+        message-id: "secrets-result"
         message: |
-          **Infisical secrets check:** :rotating_light: Secrets leaked!     
+          **Infisical secrets check:** :rotating_light: Secrets leaked!
+
+          > [!CAUTION]
+          > The Infisical CLI tool found secrets leaked in your repository.
+          > Please review the scan results and take the necessary actions.
+          > Secrets found: ${{ steps.count.outputs.secrets-leaked }}
 
           **Scan results:**
           ```
@@ -147,6 +166,6 @@ runs:
       if: cancelled()
       with:
         refresh-message-position: true
-        message-id: "secrets-result"        
+        message-id: "secrets-result"
         message: |
           **Infisical secrets check:** :o: Secrets check cancelled!


### PR DESCRIPTION
### **Description**
- Enhanced the `Infisical secrets check` GitHub action to include an output for the number of secrets leaked.
- Added a new step to count the secrets leaked found by the Infisical CLI tool.
- Improved user messages to provide better guidance on actions to take when secrets are found.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>action.yml</strong><dd><code>Enhance Infisical secrets check action with output and counting</code></dd></summary>
<hr>

action.yml
<li>Added output for the number of secrets leaked.<br> <li> Introduced a new step to count leaked secrets.<br> <li> Updated messages for better clarity and user guidance.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/github-infisical-secrets-check-action/pull/26/files#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6">+24/-5</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>