### PR TITLE
Update README.md to Remove Code Size Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # GitHub Infisical secrets check Action
 
 [![GitHub repo](https://img.shields.io/badge/GitHub-guibranco%2Fgithub--infisical--secrets--check--action-green.svg?style=plastic&logo=github)](https://github.com/guibranco/github-infisical-secrets-check-action)
-[![GitHub code size in bytes](https://img.shields.io/github/languages/code-size/guibranco/github-infisical-secrets-check-action?color=green&label=Code%20size&style=plastic&logo=github)](https://github.com/guibranco/github-infisical-secrets-check-action)
 [![GitHub last commit](https://img.shields.io/github/last-commit/guibranco/github-infisical-secrets-check-action?color=green&logo=github&style=plastic&label=Last%20commit)](https://github.com/guibranco/github-infisical-secrets-check-action)
 [![GitHub license](https://img.shields.io/github/license/guibranco/github-infisical-secrets-check-action?color=green&logo=github&style=plastic&label=License)](https://github.com/guibranco/github-infisical-secrets-check-action)
 


### PR DESCRIPTION
### **Description**
- Removed the GitHub code size badge from the README.md file.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update README to remove code size badge</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md
- Removed the GitHub code size badge.



</details>


  </td>
  <td><a href="https://github.com/guibranco/github-infisical-secrets-check-action/pull/30/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>