### PR TITLE
[CHORE] Prevent GitHub Action execution for forked pull requests

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,13 +17,13 @@ runs:
   steps:
     - name: Check if PR is from a fork
       id: check_fork
+      shell: bash
       run: |
         if [[ "${{ github.event.pull_request.head.repo.fork }}" == "true" ]]; then
           echo "FORKED=true" >> $GITHUB_ENV
         else
           echo "FORKED=false" >> $GITHUB_ENV
         fi
-
     - name: Set Infisical package source
       shell: bash
       run: curl -1sLf 'https://dl.cloudsmith.io/public/infisical/infisical-cli/setup.deb.sh' | sudo -E bash


### PR DESCRIPTION
### **User description**
## 📑 Description
This update modifies the GitHub Action workflow to detect if a pull request originates from a forked repository. If the PR comes from a fork, the workflow exits early to prevent permission-related failures when calling the GitHub API.

Changes:
Added a check using github.event.pull_request.head.repo.fork to determine if the PR originates from a fork.
If the PR is from a fork, the workflow stops execution.
Ensures API calls and other restricted steps run only for PRs from the same repository.
This prevents issues where external contributors lack sufficient permissions, improving workflow stability. 🚀

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---





___

### **Description**
- Introduced a check in the GitHub Action to identify if a pull request originates from a forked repository.
- The workflow now sets an environment variable `FORKED` to manage execution flow based on the PR's origin.
- Comments on the PR are only updated if the PR is not from a fork, preventing permission issues.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>action.yml</strong><dd><code>Enhance GitHub Action to Handle Forked PRs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

action.yml
<li>Added a check to determine if the PR is from a forked repository.<br> <li> Set environment variable <code>FORKED</code> based on the fork status.<br> <li> Updated conditions for commenting on PR based on fork status.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/github-infisical-secrets-check-action/pull/73/files#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6">+12/-3</a>&nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Automated pull request comment updates now apply only to PRs from the main repository. Forked PRs will no longer receive automated comment updates, enhancing control over feedback visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Prevent GitHub Action workflows from executing on pull requests that originate from forked repositories.

### Why are these changes being made?

This change ensures that workflows which may require access to sensitive environment variables or resources do not run on forked pull requests, which could introduce security vulnerabilities. By checking if the PR is from a fork and conditionally controlling execution based on this, the barriers to potential threats are increased without affecting internal contributions.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->