### PR TITLE
Add optional comments input +semver: minor

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,10 @@ inputs:
     description: 'GitHub token'
     required: false
     default: ${{ github.TOKEN }}
+  ADD_COMMENT:
+    description: 'Comment result in the pull request'
+    required: false
+    defualt: true
 outputs:
   secrets-leaked:
     description: "The number of secrets leaked found by the Infisical CLI tool."
@@ -127,7 +131,7 @@ runs:
 
     - name: Update PR with comment (success)
       uses: mshick/add-pr-comment@v2
-      if: success() && env.FORKED == 'false'
+      if: success() && env.FORKED == 'false' && inputs.ADD_COMMENT == 'true'
       with:
         repo-token: ${{ inputs.GH_TOKEN }}
         refresh-message-position: true
@@ -145,7 +149,7 @@ runs:
 
     - name: Update PR with comment (failure)
       uses: mshick/add-pr-comment@v2
-      if: failure() && env.FORKED == 'false'
+      if: failure() && env.FORKED == 'false' && inputs.ADD_COMMENT == 'true'
       with:
         repo-token: ${{ inputs.GH_TOKEN }}
         refresh-message-position: true
@@ -193,7 +197,7 @@ runs:
 
     - name: Update PR with comment (cancelled)
       uses: mshick/add-pr-comment@v2
-      if: cancelled() && env.FORKED == 'false'
+      if: cancelled() && env.FORKED == 'false' && inputs.ADD_COMMENT == 'true'
       with:
         repo-token: ${{ inputs.GH_TOKEN }}
         refresh-message-position: true


### PR DESCRIPTION
### **User description**
## 📑 Description
Add optional comments input 

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.


___

### **Description**
- Introduced an optional input `ADD_COMMENT` to the action configuration.
- Updated the logic to conditionally add comments to the pull request based on the value of `ADD_COMMENT`.
- This change allows users to disable comments if desired.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>action.yml</strong><dd><code>Enhance PR Commenting with Optional Input</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

action.yml
<li>Added an optional input <code>ADD_COMMENT</code> to control commenting behavior.<br> <li> Updated conditions for commenting on PR based on the new input.<br> <li> Ensured comments are only added if <code>ADD_COMMENT</code> is set to true.<br>


</details>


  </td>
  <td><a href="https://github.com/guibranco/github-infisical-secrets-check-action/pull/86/files#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions

