### PR TITLE
Use cache and pin version of Infisical

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
   ADD_COMMENT:
     description: 'Comment result in the pull request'
     required: false
-    defualt: true
+    default: true
 outputs:
   secrets-leaked:
     description: "The number of secrets leaked found by the Infisical CLI tool."
@@ -28,18 +28,48 @@ runs:
         else
           echo "FORKED=false" >> $GITHUB_ENV
         fi
-    - name: Set Infisical package source
+
+    - name: Cache pip packages
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-csvkit-v1
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - name: Cache npm global packages
+      uses: actions/cache@v4
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-npm-csv2md-v1
+        restore-keys: |
+          ${{ runner.os }}-npm-
+
+    - name: Cache Infisical CLI
+      uses: actions/cache@v4
+      id: infisical-cache
+      with:
+        path: .tools/infisical
+        key: ${{ runner.os }}-infisical-v0.41.1
+
+    - name: Install Infisical CLI if needed
+      if: steps.infisical-cache.outputs.cache-hit != 'true'
       shell: bash
-      run: curl -1sLf 'https://dl.cloudsmith.io/public/infisical/infisical-cli/setup.deb.sh' | sudo -E bash
-   
+      run: |
+        mkdir -p .tools/infisical
+        curl -sL https://github.com/Infisical/infisical/releases/download/infisical-cli%2Fv0.41.1/infisical_0.41.1_linux_amd64.tar.gz | tar -xz -C .tools/infisical
+        chmod +x .tools/infisical/infisical
+
+    - name: Add Infisical to PATH
+      shell: bash
+      run: echo "$GITHUB_WORKSPACE/.tools/infisical" >> $GITHUB_PATH
+
     - name: Install tools
       shell: bash
       run: |
         version=$(pip show pip | grep Version: | cut -d' ' -f2)
-        lower=$(printf "23.1\n$version" | sort -V | head -n1)        
-        sudo apt-get update && sudo apt-get install -y infisical
-        if [ "$lower" == "23.1" ] 
-        then
+        lower=$(printf "23.1\n$version" | sort -V | head -n1)
+        if [ "$lower" == "23.1" ]; then
           pip install csvkit --break-system-packages
         else
           pip install csvkit
@@ -141,7 +171,6 @@ runs:
 
           <details>
             <summary>💻 Scan logs</summary>
-         
             ```txt
             ${{ steps.log.outputs.contents }}
             ```
@@ -164,7 +193,6 @@ runs:
 
           <details>
             <summary>💻 Scan logs</summary>
-         
             ```txt
             ${{ steps.log.outputs.contents }}
             ```
@@ -174,8 +202,7 @@ runs:
 
           <details>
             <summary>🔎 Detected secrets in your GIT history</summary>
-            
-            ${{ steps.report.outputs.contents }}            
+            ${{ steps.report.outputs.contents }}
           </details>
 
           > [!WARNING] 
@@ -185,11 +212,10 @@ runs:
           ---
 
           <details>
-            <summary>🐾 Secrets fingerprint</summary>              
-
+            <summary>🐾 Secrets fingerprint</summary>
             ```txt
             ${{ steps.fingerprint.outputs.contents }}
-            ```              
+            ```
           </details>
 
           > [!TIP]


### PR DESCRIPTION
## 📑 Description
Use the cache and the pinned version of Infisical

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [X] Yes
- [ ] No

---

## Summary by Sourcery

Optimize GitHub Action workflow by implementing caching for Infisical CLI and pinning to a specific version

New Features:
- Add caching for pip packages
- Add caching for npm global packages
- Add caching for Infisical CLI

Bug Fixes:
- Fix typo in 'default' input parameter
- Correct package installation logic

Enhancements:
- Pin Infisical CLI to specific version (v0.41.1)
- Improve workflow performance through local package caching

Chores:
- Streamline Infisical CLI installation process