### PR TITLE
Download correct CLI version from Infisical releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The following workflow step will scan for secret leaks in your repository.
 ```yml
 - name: Infisical Secrets Check
   id: secrets-scan
-  uses: guibranco/github-infisical-secrets-check-action@v4.0.1
+  uses: guibranco/github-infisical-secrets-check-action@v4.1.0
 ```
 
 ---
@@ -59,10 +59,10 @@ jobs:
       pull-requests: write
     steps:
       - name: Infisical Secrets Check
-        uses: guibranco/github-infisical-secrets-check-action@v4.0.1
+        uses: guibranco/github-infisical-secrets-check-action@v4.1.0
 ```
 
-### With custom GitHub token
+### With a custom GitHub token
 
 ```yml
 name: Infisical secrets check
@@ -79,7 +79,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Infisical Secrets Check
-        uses: guibranco/github-infisical-secrets-check-action@v4.0.1
+        uses: guibranco/github-infisical-secrets-check-action@v4.1.0
         with:
           GH_TOKEN: ${{ secrets.CUSTOM_GH_TOKEN }}
 ```
@@ -103,7 +103,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Infisical Secrets Check
-        uses: guibranco/github-infisical-secrets-check-action@v4.0.1
+        uses: guibranco/github-infisical-secrets-check-action@v4.1.0
         with:
           ADD_COMMENT: false
 ```
@@ -126,7 +126,7 @@ jobs:
     steps:
       - name: Infisical Secrets Check
         id: secrets-scan
-        uses: guibranco/github-infisical-secrets-check-action@v4.0.1
+        uses: guibranco/github-infisical-secrets-check-action@v4.1.0
         
       - name: Handle secrets found
         if: steps.secrets-scan.outputs.secrets-leaked > 0

--- a/action.yml
+++ b/action.yml
@@ -50,25 +50,51 @@ runs:
         restore-keys: |
           ${{ runner.os }}-npm-
 
-    - name: Get latest Infisical CLI version
+    - name: Get latest valid Infisical CLI version
       id: infisical-version
       shell: bash
       run: |
-        echo "🔍 Fetching latest Infisical CLI version..."
-        JSON=$(curl -s https://api.github.com/repos/Infisical/infisical/releases/latest)
-        TAG_NAME=$(echo "$JSON" | jq -r '.tag_name')
+        echo "🔍 Fetching latest valid Infisical CLI version..."
+        
+        # Fetch all releases (up to 30 most recent)
+        JSON=$(curl -s "https://api.github.com/repos/Infisical/infisical/releases?per_page=30")
         
         # Check if we got a valid response
-        if [[ "$TAG_NAME" == "null" || -z "$TAG_NAME" ]]; then
-          echo "❌ Failed to fetch latest version from GitHub API"
+        if [[ "$JSON" == "null" || -z "$JSON" || "$JSON" == "[]" ]]; then
+          echo "❌ Failed to fetch releases from GitHub API"
           echo "Response: $JSON"
           echo "FETCH_FAILED=true" >> $GITHUB_ENV
           exit 1
         fi
         
+        # Find the first release that matches our criteria:
+        # 1. Tag name starts with "infisical-cli/v"
+        # 2. Tag name does not contain "-postgres"
+        # 3. Is not a prerelease
+        # 4. Is not a draft
+        TAG_NAME=$(echo "$JSON" | jq -r '
+          .[] | 
+          select(.draft == false) |
+          select(.prerelease == false) |
+          select(.tag_name | startswith("infisical-cli/v")) |
+          select(.tag_name | contains("-postgres") | not) |
+          .tag_name |
+          select(. != null)' | head -n1)
+        
+        # Check if we found a valid tag
+        if [[ "$TAG_NAME" == "null" || -z "$TAG_NAME" ]]; then
+          echo "❌ No valid Infisical CLI release found"
+          echo "Available releases:"
+          echo "$JSON" | jq -r '.[] | select(.draft == false) | .tag_name' | head -10
+          echo "FETCH_FAILED=true" >> $GITHUB_ENV
+          exit 1
+        fi
+        
+        # Extract version from tag (remove "infisical-cli/v" prefix)
         VERSION=$(echo "$TAG_NAME" | sed 's|infisical-cli/v||')
-        echo "🔍 Latest version: $VERSION"
+        echo "🔍 Found valid CLI version: $VERSION (tag: $TAG_NAME)"
         echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+        echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
         echo "FETCH_FAILED=false" >> $GITHUB_ENV
 
     - name: Cache Infisical CLI
@@ -84,9 +110,11 @@ runs:
       shell: bash
       run: |
         VERSION=${{ steps.infisical-version.outputs.version }}
-        TAG_NAME="infisical-cli/v$VERSION"
+        TAG_NAME=${{ steps.infisical-version.outputs.tag_name }}
         ASSET="infisical_${VERSION}_linux_amd64.tar.gz"
-        URL="https://github.com/Infisical/infisical/releases/download/${TAG_NAME//\//%2F}/$ASSET"
+        # URL encode the tag name for the download URL
+        ENCODED_TAG=$(echo "$TAG_NAME" | sed 's|/|%2F|g')
+        URL="https://github.com/Infisical/infisical/releases/download/$ENCODED_TAG/$ASSET"
 
         echo "⬇️ Downloading Infisical CLI $VERSION from $URL"
         mkdir -p .tools/infisical
@@ -94,6 +122,8 @@ runs:
         # Download and verify
         if ! curl -sL "$URL" | tar -xz -C .tools/infisical; then
           echo "❌ Failed to download or extract Infisical CLI"
+          echo "❌ URL attempted: $URL"
+          echo "❌ Asset expected: $ASSET"
           echo "INSTALL_FAILED=true" >> $GITHUB_ENV
           exit 1
         fi


### PR DESCRIPTION
## 📑 Description

This PR fixes an issue where the GitHub Action would sometimes download invalid Infisical CLI releases that contain a `-postgres` suffix and lack the necessary binaries to run the tool.

### Problem
The existing code fetched only the latest release using `/releases/latest`, which could return releases like `infisical/v0.133.1-postgres` that don't contain the CLI binaries. This caused the action to fail when trying to download and extract the expected `infisical_VERSION_linux_amd64.tar.gz` asset.

### Solution
- **Enhanced Release Filtering**: Modified the version fetching logic to retrieve up to 30 recent releases and filter them based on multiple criteria:
  - Must start with `infisical-cli/v` prefix (correct CLI releases)
  - Must not contain `-postgres` suffix
  - Must not be a draft or pre-release
- **Improved Error Handling**: Added better debugging output when no valid release is found
- **Robust URL Construction**: Now stores both the cleaned version number and full tag name for proper download URL construction

### Changes Made
1. Updated the "Get latest valid Infisical CLI version" step to fetch multiple releases instead of just the latest
2. Added comprehensive jq filtering to identify valid CLI releases
3. Enhanced error messages with debugging information
4. Improved download URL construction using the correct tag format

### Expected Behavior
The action will now reliably find and download valid Infisical CLI releases (e.g., `infisical-cli/v0.41.86`) while skipping invalid ones (e.g., `infisical/v0.133.1-postgres`), ensuring consistent functionality across all workflow runs.

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.

## Summary by Sourcery

Enhance the GitHub Action to reliably fetch and download valid Infisical CLI releases by querying recent releases, filtering unwanted tags, and constructing URLs with detailed error reporting.

Bug Fixes:
- Prevent the action from selecting '-postgres' releases that lack CLI binaries.

Enhancements:
- Query multiple releases and filter for valid 'infisical-cli/v' tags, excluding drafts, prereleases, and '-postgres' variants.
- Capture and output both the cleaned version and full tag name, then URL-encode the tag in download URLs.
- Improve error handling with detailed debug output for release fetch or download failures.

Documentation:
- Bump GitHub Action usage examples in README from v4.0.1 to v4.1.0.
- Correct README wording for custom GitHub token usage.