### PR TITLE
Increase releases list in API response

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -57,7 +57,7 @@ runs:
         echo "🔍 Fetching latest valid Infisical CLI version..."
         
         # Fetch all releases (up to 30 most recent)
-        JSON=$(curl -s "https://api.github.com/repos/Infisical/infisical/releases?per_page=50")
+        JSON=$(curl -s "https://api.github.com/repos/Infisical/infisical/releases?per_page=100")
         
         # Check if we got a valid response
         if [[ "$JSON" == "null" || -z "$JSON" || "$JSON" == "[]" ]]; then


### PR DESCRIPTION
## 📑 Description
Increase releases list in API response

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---




## Summary by Sourcery

Enhancements:
- Bump per_page parameter from 50 to 100 in action.yml to retrieve more releases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded the automation workflow’s GitHub API request to fetch up to 100 releases (previously 50), providing broader coverage during release evaluation.
  * Validation, multi-criteria filtering, version extraction, error handling, and outputs remain unchanged.
  * No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Increase the number of releases fetched in the API response from 50 to 100.

### Why are these changes being made?

This change addresses the need to access a larger set of releases for better historical data analysis and version tracking. By expanding the fetch limit, more comprehensive data can be retrieved without requiring additional API calls, enhancing efficiency.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->