### PR TITLE
Infisical CLI version resolution: fallback when asset is missing +semver: minor

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -66,37 +66,58 @@ runs:
           echo "FETCH_FAILED=true" >> $GITHUB_ENV
           exit 1
         fi
-        
+    
+        ARCH="linux_amd64"
+        FOUND_VERSION=""
+        FOUND_TAG=""
+    
         # Find the first release that matches our criteria:
         # 1. Tag name starts with "v"
         # 2. Tag name does not contain "-postgres"
         # 3. Is not a prerelease
         # 4. Is not a draft
-        TAG_NAME=$(echo "$JSON" | jq -r '
+        # 5. Has the expected CLI asset for this architecture
+        while IFS= read -r TAG_NAME; do
+          # Extract version from tag (remove "v" prefix)
+          VERSION=$(echo "$TAG_NAME" | sed 's|v||')
+          ASSET="cli_${VERSION}_${ARCH}.tar.gz"
+    
+          # Check if the release actually contains the expected asset
+          HAS_ASSET=$(echo "$JSON" | jq -r --arg tag "$TAG_NAME" --arg asset "$ASSET" '
+            .[] | select(.tag_name == $tag) | .assets[] | select(.name == $asset) | .name
+          ')
+    
+          if [[ -n "$HAS_ASSET" ]]; then
+            echo "✅ Found release $TAG_NAME with asset $ASSET"
+            FOUND_VERSION="$VERSION"
+            FOUND_TAG="$TAG_NAME"
+            break
+          else
+            echo "⚠️  Release $TAG_NAME does not have asset $ASSET, skipping..."
+          fi
+        done < <(echo "$JSON" | jq -r '
           .[] | 
           select(.draft == false) |
           select(.prerelease == false) |
           select(.tag_name | startswith("v")) |
           select(.tag_name | contains("-postgres") | not) |
           .tag_name |
-          select(. != null)' | head -n1)
+          select(. != null)
+        ')
         
         # Check if we found a valid tag
-        if [[ "$TAG_NAME" == "null" || -z "$TAG_NAME" ]]; then
-          echo "❌ No valid Infisical CLI release found"
+        if [[ -z "$FOUND_VERSION" || -z "$FOUND_TAG" ]]; then
+          echo "❌ No valid Infisical CLI release found with the expected asset"
           echo "Available releases:"
           echo "$JSON" | jq -r '.[] | select(.draft == false) | .tag_name' | head -10
           echo "FETCH_FAILED=true" >> $GITHUB_ENV
           exit 1
         fi
         
-        # Extract version from tag (remove "v" prefix)
-        VERSION=$(echo "$TAG_NAME" | sed 's|v||')
-        echo "🔍 Found valid CLI version: $VERSION (tag: $TAG_NAME)"
-        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-        echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
+        echo "🔍 Found valid CLI version: $FOUND_VERSION (tag: $FOUND_TAG)"
+        echo "version=$FOUND_VERSION" >> "$GITHUB_OUTPUT"
+        echo "tag_name=$FOUND_TAG" >> "$GITHUB_OUTPUT"
         echo "FETCH_FAILED=false" >> $GITHUB_ENV
-
     - name: Cache Infisical CLI
       uses: actions/cache@v5
       id: infisical-cache


### PR DESCRIPTION
## 🔍 Infisical CLI version resolution: fallback when asset is missing

### Problem

Some Infisical CLI releases are published without the expected platform asset (e.g. `cli_0.43.66_linux_amd64.tar.gz`). The previous implementation selected the first metadata-valid release (non-draft, non-prerelease, no `-postgres` suffix) but did not verify that the actual download asset was present in that release. This caused the workflow to fail at the download step with:

```
gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
❌ Failed to download or extract Infisical CLI
```

### Solution

Updated the `Get latest valid Infisical CLI version` step to iterate through candidate releases in order and verify that the expected asset (`cli_<version>_linux_amd64.tar.gz`) is present in each release's `assets` array before selecting it. The first release that satisfies both the metadata criteria **and** has the asset available is used.

This validation is done entirely against the already-fetched API response — no extra HTTP requests are made per release, so there is no performance impact in the happy path.

### Changes

- Replaced single `jq` + `head -n1` selection with an iteration loop over all candidate releases
- Added asset presence check via `jq` on the `assets[]` array of each release
- Releases missing the expected asset emit a `⚠️ skipping` log line for observability
- Failure message now lists available releases to aid debugging, consistent with prior behavior
- Extracted architecture string into an `ARCH` variable for clarity
- All original comments preserved; updated criterion list to document the new asset check (#5)

### Example log output (skipping a bad release)

```
🔍 Fetching latest valid Infisical CLI version...
⚠️  Release v0.43.66 does not have asset cli_0.43.66_linux_amd64.tar.gz, skipping...
✅ Found release v0.43.65 with asset cli_0.43.65_linux_amd64.tar.gz
🔍 Found valid CLI version: 0.43.65 (tag: v0.43.65)
```

### Type of change

- [x] Bug fix (resolves intermittent workflow failures on incomplete releases)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Summary by Sourcery

Ensure the GitHub Action selects an Infisical CLI release that actually includes the expected Linux AMD64 asset before proceeding.

Bug Fixes:
- Prevent workflow failures by skipping Infisical CLI releases that are missing the expected linux_amd64 tarball asset.

Enhancements:
- Iterate over candidate releases with logging to choose the first valid tag that includes the required asset and expose selected version/tag via updated variables for clarity.