### PR TITLE
Add .infisicalignore commit suggestion support to PR comments +semver: major

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -278,6 +278,43 @@ runs:
       with:
         path: fingerprint.txt
 
+    - name: Check if .infisicalignore exists
+      id: ignorefile
+      shell: bash
+      if: env.SECRETS_FOUND == 'true'
+      run: |
+        if [[ -f ".infisicalignore" ]]; then
+          echo "exists=true" >> $GITHUB_OUTPUT
+        else
+          echo "exists=false" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Prepare ignore file suggestion
+      id: ignore_suggestion
+      shell: bash
+      if: env.SECRETS_FOUND == 'true'
+      run: |
+        echo "Preparing suggestion block..."
+
+        if [[ "${{ steps.ignorefile.outputs.exists }}" == "true" ]]; then
+          echo "Appending fingerprints to existing .infisicalignore"
+          cat .infisicalignore > new-ignorefile.txt
+          echo "" >> new-ignorefile.txt
+          cat fingerprint.txt >> new-ignorefile.txt
+        else
+          echo "Creating new .infisicalignore"
+          cat fingerprint.txt > new-ignorefile.txt
+        fi
+
+        # Remove duplicates (optional improvement)
+        sort -u new-ignorefile.txt -o new-ignorefile.txt
+
+        echo "suggestion<<EOF" >> $GITHUB_OUTPUT
+        echo '```suggestion:.infisicalignore' >> $GITHUB_OUTPUT
+        cat new-ignorefile.txt >> $GITHUB_OUTPUT
+        echo '```' >> $GITHUB_OUTPUT
+        echo "EOF" >> $GITHUB_OUTPUT
+
     - name: Update PR with comment (success)
       uses: mshick/add-pr-comment@v3
       if: env.SCAN_RAN == 'true' && env.SECRETS_FOUND == 'false' && env.FORKED == 'false' && inputs.ADD_COMMENT == 'true'
@@ -343,7 +380,9 @@ runs:
           </details>
 
           > [!TIP]
-          > If you want to ignore these leaked secrets, add the above **fingerprint** content to a file named `.infisicalignore` at the repository root level.
+          > You can commit the fingerprint list below to automatically create or update `.infisicalignore`:
+
+          ${{ steps.ignore_suggestion.outputs.suggestion }}
 
     - name: Update PR with comment (tool failure)
       uses: mshick/add-pr-comment@v3


### PR DESCRIPTION
## 📑 Description

This pull request enhances the Infisical secrets check action by adding an automated **commit suggestion workflow** that allows developers to create or update the `.infisicalignore` file directly from the pull request UI.

When leaked secrets are detected:

- The action now checks whether `.infisicalignore` already exists in the repository
- If the file exists, detected fingerprints are appended
- If the file does not exist, the file is created automatically
- Duplicate fingerprints are removed before generating suggestions
- A GitHub **Commit suggestion button** is rendered inside the PR comment
- Contributors can apply the ignore list without leaving the pull request interface

This significantly improves usability by turning the action into an interactive remediation workflow instead of only reporting scan results.

### Why this is a major version bump

The PR comment output format changes by introducing a suggestion block that enables direct commits from the UI. While backwards compatible in behavior, this modifies the generated comment structure and downstream integrations relying on exact comment formatting may be affected.

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Add support for suggesting .infisicalignore updates directly within PR comments when leaked secrets are detected.

New Features:
- Generate a commit-ready .infisicalignore suggestion block in PR comments based on detected secret fingerprints.

Enhancements:
- Automatically create or update the suggested .infisicalignore content by merging existing entries with new fingerprints and de-duplicating them.